### PR TITLE
feat: Add gitsigns and lualine for enhanced git integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,14 @@ This is a dotfiles repository containing personal configuration files for variou
 - `nvim/` - Neovim configuration
   - `.config/nvim/init.lua` - Main Neovim configuration file
   - `.config/nvim/lazy-lock.json` - Plugin lock file for Lazy.nvim
+  - `.config/nvim/lua/plugins/` - Modular plugin configurations
+    - `colorscheme.lua` - Catppuccin theme configuration
+    - `devicons.lua` - File and folder icons
+    - `gitsigns.lua` - Git decorations and hunks
+    - `lsp.lua` - Language Server Protocol setup
+    - `lualine.lua` - Status line with git info
+    - `telescope.lua` - Fuzzy finder
+    - `treesitter.lua` - Syntax highlighting
 - `zsh/` - Zsh shell configuration
   - `.zshrc` - Zsh configuration (currently minimal, only contains pnpm PATH)
 
@@ -19,6 +27,20 @@ This is a dotfiles repository containing personal configuration files for variou
 - **Neovim**: Uses Lazy.nvim as plugin manager
 - **LSP**: Configured with mason.nvim for language server management
 - **Shell**: Zsh with pnpm in PATH
+
+## Prerequisites
+
+### Nerd Font Requirement
+For proper display of icons in Neovim (git status, file icons, diagnostics), you need a Nerd Font installed:
+- Recommended fonts: JetBrains Mono Nerd Font, Fira Code Nerd Font, Hack Nerd Font
+- Download from: https://www.nerdfonts.com/
+- Set your terminal to use the installed Nerd Font
+
+Without a Nerd Font, you'll see broken characters instead of icons in:
+- Gitsigns (git status in the gutter)
+- Lualine status line (file types, git branch, etc.)
+- LSP diagnostics (error/warning icons)
+- Telescope (file type icons)
 
 ## Development Notes
 

--- a/nvim/.config/nvim/lua/plugins/devicons.lua
+++ b/nvim/.config/nvim/lua/plugins/devicons.lua
@@ -1,0 +1,8 @@
+return {
+  "nvim-tree/nvim-web-devicons",
+  lazy = true,
+  opts = {
+    -- your configuration comes here
+    -- or leave it empty to use the default settings
+  },
+}

--- a/nvim/.config/nvim/lua/plugins/gitsigns.lua
+++ b/nvim/.config/nvim/lua/plugins/gitsigns.lua
@@ -1,0 +1,101 @@
+return {
+  "lewis6991/gitsigns.nvim",
+  event = { "BufReadPre", "BufNewFile" },
+  opts = {
+    signs = {
+      add = { text = "▎" },
+      change = { text = "▎" },
+      delete = { text = "" },
+      topdelete = { text = "" },
+      changedelete = { text = "▎" },
+      untracked = { text = "▎" },
+    },
+    signcolumn = true,
+    numhl = false,
+    linehl = false,
+    word_diff = false,
+    watch_gitdir = {
+      interval = 1000,
+      follow_files = true,
+    },
+    attach_to_untracked = true,
+    current_line_blame = true,
+    current_line_blame_opts = {
+      virt_text = true,
+      virt_text_pos = "eol",
+      delay = 1000,
+      ignore_whitespace = false,
+    },
+    current_line_blame_formatter = "<author>, <author_time:%Y-%m-%d> - <summary>",
+    sign_priority = 6,
+    update_debounce = 100,
+    status_formatter = nil,
+    max_file_length = 40000,
+    preview_config = {
+      border = "single",
+      style = "minimal",
+      relative = "cursor",
+      row = 0,
+      col = 1,
+    },
+    yadm = {
+      enable = false,
+    },
+    on_attach = function(bufnr)
+      local gs = package.loaded.gitsigns
+
+      local function map(mode, l, r, opts)
+        opts = opts or {}
+        opts.buffer = bufnr
+        vim.keymap.set(mode, l, r, opts)
+      end
+
+      -- Navigation
+      map("n", "]c", function()
+        if vim.wo.diff then
+          return "]c"
+        end
+        vim.schedule(function()
+          gs.next_hunk()
+        end)
+        return "<Ignore>"
+      end, { expr = true, desc = "Next Hunk" })
+
+      map("n", "[c", function()
+        if vim.wo.diff then
+          return "[c"
+        end
+        vim.schedule(function()
+          gs.prev_hunk()
+        end)
+        return "<Ignore>"
+      end, { expr = true, desc = "Prev Hunk" })
+
+      -- Actions
+      map("n", "<leader>hs", gs.stage_hunk, { desc = "Stage Hunk" })
+      map("n", "<leader>hr", gs.reset_hunk, { desc = "Reset Hunk" })
+      map("v", "<leader>hs", function()
+        gs.stage_hunk({ vim.fn.line("."), vim.fn.line("v") })
+      end, { desc = "Stage Hunk" })
+      map("v", "<leader>hr", function()
+        gs.reset_hunk({ vim.fn.line("."), vim.fn.line("v") })
+      end, { desc = "Reset Hunk" })
+      map("n", "<leader>hS", gs.stage_buffer, { desc = "Stage Buffer" })
+      map("n", "<leader>hu", gs.undo_stage_hunk, { desc = "Undo Stage Hunk" })
+      map("n", "<leader>hR", gs.reset_buffer, { desc = "Reset Buffer" })
+      map("n", "<leader>hp", gs.preview_hunk, { desc = "Preview Hunk" })
+      map("n", "<leader>hb", function()
+        gs.blame_line({ full = true })
+      end, { desc = "Blame Line" })
+      map("n", "<leader>tb", gs.toggle_current_line_blame, { desc = "Toggle Blame" })
+      map("n", "<leader>hd", gs.diffthis, { desc = "Diff This" })
+      map("n", "<leader>hD", function()
+        gs.diffthis("~")
+      end, { desc = "Diff This ~" })
+      map("n", "<leader>td", gs.toggle_deleted, { desc = "Toggle Deleted" })
+
+      -- Text object
+      map({ "o", "x" }, "ih", ":<C-U>Gitsigns select_hunk<CR>", { desc = "GitSigns Select Hunk" })
+    end,
+  },
+}

--- a/nvim/.config/nvim/lua/plugins/lualine.lua
+++ b/nvim/.config/nvim/lua/plugins/lualine.lua
@@ -1,0 +1,101 @@
+return {
+  "nvim-lualine/lualine.nvim",
+  event = "VeryLazy",
+  dependencies = { "nvim-tree/nvim-web-devicons" },
+  opts = {
+    options = {
+      theme = "catppuccin",
+      component_separators = { left = "", right = "" },
+      section_separators = { left = "", right = "" },
+      disabled_filetypes = {
+        statusline = { "dashboard", "alpha", "starter" },
+      },
+      always_divide_middle = true,
+      globalstatus = true,
+    },
+    sections = {
+      lualine_a = { "mode" },
+      lualine_b = {
+        "branch",
+        {
+          "diff",
+          symbols = {
+            added = " ",
+            modified = " ",
+            removed = " ",
+          },
+          source = function()
+            local gitsigns = vim.b.gitsigns_status_dict
+            if gitsigns then
+              return {
+                added = gitsigns.added,
+                modified = gitsigns.changed,
+                removed = gitsigns.removed,
+              }
+            end
+          end,
+        },
+      },
+      lualine_c = {
+        {
+          "filename",
+          path = 1,
+          symbols = {
+            modified = " ●",
+            readonly = " ",
+            unnamed = "[No Name]",
+          },
+        },
+        {
+          "diagnostics",
+          sources = { "nvim_diagnostic" },
+          symbols = {
+            error = " ",
+            warn = " ",
+            info = " ",
+            hint = " ",
+          },
+        },
+      },
+      lualine_x = {
+        {
+          function()
+            local msg = "No Active Lsp"
+            local buf_ft = vim.api.nvim_buf_get_option(0, "filetype")
+            local clients = vim.lsp.get_active_clients()
+            if next(clients) == nil then
+              return msg
+            end
+            for _, client in ipairs(clients) do
+              local filetypes = client.config.filetypes
+              if filetypes and vim.fn.index(filetypes, buf_ft) ~= -1 then
+                return client.name
+              end
+            end
+            return msg
+          end,
+          icon = " LSP:",
+          color = { gui = "bold" },
+        },
+        {
+          "filetype",
+          icon_only = true,
+          separator = "",
+          padding = { left = 1, right = 0 },
+        },
+      },
+      lualine_y = { "progress" },
+      lualine_z = { "location" },
+    },
+    inactive_sections = {
+      lualine_a = {},
+      lualine_b = {},
+      lualine_c = { "filename" },
+      lualine_x = { "location" },
+      lualine_y = {},
+      lualine_z = {},
+    },
+    tabline = {},
+    extensions = { "neo-tree", "lazy" },
+  },
+}


### PR DESCRIPTION
## Summary
- Add comprehensive git integration to Neovim with gitsigns and status line enhancements
- Includes visual git indicators and interactive hunk management
- Requires Nerd Font for proper icon display

## Changes
- **Gitsigns**: Visual git status in the gutter with extensive keymaps for hunk management
- **Lualine**: Modern status line showing git branch, diff stats, LSP status, and file info
- **Icons**: Add nvim-web-devicons for file type icons throughout the interface
- **Documentation**: Update CLAUDE.md with Nerd Font requirements and plugin structure

## Features Added
- ✨ Git status indicators in the sign column (added, modified, deleted lines)
- 🔄 Interactive hunk staging and navigation with `]c`/`[c` and `<leader>hs`/`<leader>hr`
- 📝 Current line git blame with author and timestamp
- 📊 Status line with git branch, diff statistics, and active LSP server
- 📁 File type icons in status line and throughout interface
- ⌨️ Comprehensive keymaps for git operations

## Keymaps Added
- `]c` / `[c` - Navigate between hunks
- `<leader>hs` - Stage hunk
- `<leader>hr` - Reset hunk
- `<leader>hS` - Stage entire buffer
- `<leader>hR` - Reset entire buffer
- `<leader>hp` - Preview hunk
- `<leader>hb` - Show line blame
- `<leader>tb` - Toggle current line blame
- `ih` - Text object for git hunks

## Prerequisites
⚠️ **Requires Nerd Font**: Download and install a Nerd Font (JetBrains Mono, Fira Code, etc.) and configure your terminal to use it for proper icon display.

## Test Plan
- [ ] Install a Nerd Font and configure terminal
- [ ] Test git status indicators in a git repository
- [ ] Verify hunk navigation with `]c` and `[c`
- [ ] Test hunk staging/unstaging with `<leader>hs` and `<leader>hr`
- [ ] Check status line displays git branch and diff stats
- [ ] Verify LSP server name appears in status line
- [ ] Test current line blame functionality

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added modular configuration for Neovim plugins, including devicons, gitsigns, and lualine.
  * Enhanced statusline with theme support, LSP status, git integration, and diagnostics display.
  * Introduced customizable git signs and inline blame annotations.
* **Documentation**
  * Expanded documentation to detail plugin configuration structure and added a prerequisites section highlighting the need for Nerd Fonts for proper icon display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->